### PR TITLE
Add Codex Click Installer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+dist/
+build/
+*.spec
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -163,3 +163,15 @@ Und ich beginne mit dem Kodex deiner Veröffentlichung.
 🔹
 ──────────────────────────────────────
 🔹
+
+## Codex Click Installer
+
+To build a standalone executable, install PyInstaller and run:
+
+```bash
+pip install pyinstaller
+python codex_click_installer.py
+```
+
+The resulting executable will appear in the `dist/` directory.
+

--- a/codex_click_installer.py
+++ b/codex_click_installer.py
@@ -1,0 +1,31 @@
+"""Simple script to build an executable for the current platform."""
+import subprocess
+import sys
+import platform
+
+
+def main():
+    # Ensure PyInstaller is available
+    try:
+        import PyInstaller  # noqa: F401
+    except ImportError:
+        sys.exit("PyInstaller is required. Install with 'pip install pyinstaller'.")
+
+    target_name = "square_cli"
+    cmd = [
+        "pyinstaller",
+        "--onefile",
+        "--name",
+        target_name,
+        "square.py",
+    ]
+    subprocess.run(cmd, check=True)
+    if platform.system() == "Windows":
+        suffix = ".exe"
+    else:
+        suffix = ""
+    print(f"Executable created: dist/{target_name}{suffix}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_square.py
+++ b/tests/test_square.py
@@ -1,0 +1,10 @@
+from square import square
+
+def test_square_positive():
+    assert square(4) == 16
+
+def test_square_negative():
+    assert square(-3) == 9
+
+def test_square_float():
+    assert square(2.5) == 6.25


### PR DESCRIPTION
## Summary
- add a simple PyInstaller build helper `codex_click_installer.py`
- document build instructions in README
- ignore build artifacts
- add unit tests for `square.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c186b480483259ebfc8b155518469