### PR TITLE
Resolve README conflict and format code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+dist/
+build/
+*.spec
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -163,3 +163,19 @@ Und ich beginne mit dem Kodex deiner Veröffentlichung.
 🔹
 ──────────────────────────────────────
 🔹
+
+## Codex Click Installer
+
+To build a standalone executable, install the required packages and run:
+
+```bash
+pip install -r requirements.txt
+python codex_click_installer.py
+```
+
+The script will automatically install PyInstaller if it's not already
+available on your system. The resulting executable will appear in the
+`dist/` directory.
+
+
+Run this script on each platform (Windows, macOS, Linux) to produce the corresponding executable.

--- a/codex_click_installer.py
+++ b/codex_click_installer.py
@@ -1,0 +1,39 @@
+"""Simple script to build an executable for the current platform."""
+
+import subprocess
+import sys
+import platform
+
+
+def main():
+    # Ensure PyInstaller is available
+    try:
+        import PyInstaller  # noqa: F401
+    except ImportError:
+        try:
+            subprocess.check_call(
+                [sys.executable, "-m", "pip", "install", "pyinstaller"]
+            )
+        except subprocess.CalledProcessError as exc:
+            sys.exit(
+                "PyInstaller is required. Install with 'pip install pyinstaller'."
+            )
+
+    target_name = "square_cli"
+    cmd = [
+        "pyinstaller",
+        "--onefile",
+        "--name",
+        target_name,
+        "square.py",
+    ]
+    subprocess.run(cmd, check=True)
+    if platform.system() == "Windows":
+        suffix = ".exe"
+    else:
+        suffix = ""
+    print(f"Executable created: dist/{target_name}{suffix}")
+
+
+if __name__ == "__main__":
+    main()

--- a/codex_click_installer.py
+++ b/codex_click_installer.py
@@ -14,9 +14,10 @@ def main():
             subprocess.check_call(
                 [sys.executable, "-m", "pip", "install", "pyinstaller"]
             )
-        except subprocess.CalledProcessError as exc:
+        except subprocess.CalledProcessError:
             sys.exit(
-                "PyInstaller is required. Install with 'pip install pyinstaller'."
+                "PyInstaller is required. "
+                "Install with 'pip install pyinstaller'."
             )
 
     target_name = "square_cli"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+pyinstaller

--- a/square.py
+++ b/square.py
@@ -1,10 +1,11 @@
-
 def square(n: float) -> float:
     """Return the square of a number."""
     return n * n
 
+
 if __name__ == "__main__":
     import sys
+
     if len(sys.argv) > 1:
         try:
             value = float(sys.argv[1])

--- a/tests/test_square.py
+++ b/tests/test_square.py
@@ -1,10 +1,13 @@
 from square import square
 
+
 def test_square_positive():
     assert square(4) == 16
 
+
 def test_square_negative():
     assert square(-3) == 9
+
 
 def test_square_float():
     assert square(2.5) == 6.25

--- a/tests/test_square.py
+++ b/tests/test_square.py
@@ -1,0 +1,10 @@
+from square import square
+
+def test_square_positive():
+    assert square(4) == 16
+
+def test_square_negative():
+    assert square(-3) == 9
+
+def test_square_float():
+    assert square(2.5) == 6.25


### PR DESCRIPTION
## Summary
- clarify README instructions for building an executable
- format Python files with black
- add error handling for PyInstaller installation

## Testing
- `pytest -q`
- `python codex_click_installer.py`


------
https://chatgpt.com/codex/tasks/task_e_684c186b480483259ebfc8b155518469